### PR TITLE
FIX: correctly handle unknown length tuples

### DIFF
--- a/nectarine/typing.py
+++ b/nectarine/typing.py
@@ -183,17 +183,16 @@ def is_conform_to_hint(value, hint: Type) -> bool:
             return False
         args = get_generic_args(hint)
         if issubclass(origin, Mapping):
-            key_type = args[0]
-            value_type = args[1]
+            assert len(args) >= 2
+            key_type, value_type = args[0], args[1]
             return all(is_conform_to_hint(k, key_type) and is_conform_to_hint(v, value_type) for k, v in value.items())
+        assert len(args) >= 1
+        value_type = args[0]
         if origin is tuple:
             if is_tuple_of_unknown_length(hint):
-                value_type = args[1]
                 return all(is_conform_to_hint(v, value_type) for v in value)
             else:
                 return len(args) == len(value) and all(is_conform_to_hint(v, h) for v, h in zip(value, args))
-        assert len(args) == 1
-        value_type = args[0]
         return all(is_conform_to_hint(v, value_type) for v in value)
     if is_literal(hint):
         args = get_generic_args(hint)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -128,9 +128,16 @@ def test_is_conform_to_hint():
     assert is_conform_to_hint("abc", str)
     assert is_conform_to_hint(None, Optional[str])
     assert is_conform_to_hint("abc", Union[str, int])
+    assert is_conform_to_hint((1,2,3), Tuple[int, int, int])
+    assert is_conform_to_hint((1,2,3), Tuple[int, ...])
+    assert is_conform_to_hint([1,2,3], List[int])
+    
 
     assert not is_conform_to_hint(1, str)
     assert not is_conform_to_hint(1., int)
     assert not is_conform_to_hint(1, str)
     assert not is_conform_to_hint(None, str)
     assert not is_conform_to_hint("abc", Union[float, int])
+    assert not is_conform_to_hint((1,2,3), Tuple[int, int])
+    assert not is_conform_to_hint(tuple('abc'), Tuple[int, ...])
+    assert not is_conform_to_hint([1.2,3.2], List[int])


### PR DESCRIPTION
As per [the documentation](https://docs.python.org/3/library/typing.html#typing.Tuple) a variable length tuple type hint is of the form `foo : Tuple[T,...]`. Currently `nectarine` would end up checking `isinstance(value, Ellipsis)` instead of `isinstance(value, T)`.

I've added some unit test to highlight the issue, and tweaked the `is_conform_to_hint` method to correctly handle variable length tuple hints.